### PR TITLE
Add new monitoring: unused CSS and JS coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN mkdir reports
 
 RUN npm install --production
 
-CMD [ "npm", "run", "unused-css-js" ]
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 li
 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+libappindicator3-1 libatk-bridge2.0-0 libgbm1 \
 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
 apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
@@ -22,4 +23,4 @@ RUN mkdir reports
 
 RUN npm install --production
 
-CMD [ "npm", "start" ]
+CMD [ "npm", "run", "unused-css-js" ]

--- a/k8s/cron-job.yaml
+++ b/k8s/cron-job.yaml
@@ -98,3 +98,23 @@ spec:
             - run
             - adplaces
           restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: frontend-monitoring-unused-css-js
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "*/55 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: unused-css-js
+            image: eu.gcr.io/zeitonline-210413/frontend-monitoring:v0.1
+            command:
+            - npm
+            - run
+            - unused-css-js
+          restartPolicy: OnFailure

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "html-validator": "^5.1.17",
         "jsdom": "^16.5.1",
         "node-fetch": "^2.6.1",
-        "pa11y": "^5.3.0"
+        "pa11y": "^5.3.0",
+        "puppeteer": "^1.20.0"
       },
       "devDependencies": {
         "eslint": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-monitoring",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Valentin von Guttenberg <greengiraffe@posteo.de>",
   "contributors": [
     "Thomas Puppe <info@thomaspuppe.de>",
@@ -19,7 +19,8 @@
     "html-validator": "^5.1.17",
     "jsdom": "^16.5.1",
     "node-fetch": "^2.6.1",
-    "pa11y": "^5.3.0"
+    "pa11y": "^5.3.0",
+    "puppeteer": "^1.20.0"
   },
   "scripts": {
     "cssstats": "node src/checks/cssstats/index.js",
@@ -28,7 +29,8 @@
     "webcoach": "node src/checks/webcoach/index.js",
     "homepagestats": "node src/checks/homepagestats/index.js",
     "adplaces": "node src/checks/adplaces/index.js",
-    "start": "npm run cssstats && npm run htmlvalidator && npm run pa11y && npm run homepagestats && npm run webcoach && npm run adplaces"
+    "unused-css-js": "node src/checks/unused-css-js/index.js",
+    "start": "npm run cssstats && npm run htmlvalidator && npm run pa11y && npm run homepagestats && npm run webcoach && npm run adplaces && npm run unused-css-js"
   },
   "devDependencies": {
     "eslint": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "get-css": "^4.0.3",
     "graphite": "^0.1.4",
     "html-validator": "^5.1.17",
-    "jsdom": "^16.5.1",
+    "jsdom": "^16.5.3",
     "node-fetch": "^2.6.1",
-    "pa11y": "^5.3.0",
-    "puppeteer": "^1.20.0"
+    "pa11y": "^5.3.1",
+    "puppeteer": "^8.0.0"
   },
   "scripts": {
     "cssstats": "node src/checks/cssstats/index.js",
@@ -33,11 +33,10 @@
     "start": "npm run cssstats && npm run htmlvalidator && npm run pa11y && npm run homepagestats && npm run webcoach && npm run adplaces && npm run unused-css-js"
   },
   "devDependencies": {
-    "eslint": "^7.22.0",
-    "eslint-config-standard": "^16.0.2",
+    "eslint": "^7.24.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.3.1",
+    "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0"
   }
 }

--- a/src/checks/unused-css-js/check.js
+++ b/src/checks/unused-css-js/check.js
@@ -1,0 +1,102 @@
+const puppeteer = require('puppeteer')
+
+const saveRawData = require('./../../utils/saveRawData')
+const sendToGraphite = require('./../../utils/sendToGraphite')
+
+const statsFilter = require('./filters/stats')
+const CONFIG = require('../../config/config')
+
+exports = module.exports = {}
+
+exports.run = function run (siteName, siteType, url) {
+
+    return (async () => {
+        const browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        page.setUserAgent(CONFIG.userAgent)
+
+        await Promise.all([
+            page.coverage.startJSCoverage(),
+            page.coverage.startCSSCoverage()
+        ]);
+
+        await page.goto(url);
+
+        //Retrive the coverage objects
+        const [jsCoverage, cssCoverage] = await Promise.all([
+            page.coverage.stopJSCoverage(),
+            page.coverage.stopCSSCoverage(),
+        ]);
+
+        sendToGraphite({
+          frontendmonitoring: {
+              cssCoverage: {
+                [siteName]: {
+                  [siteType]: statsFilter(cssCoverage)
+                }
+              }
+          }
+        })
+        //console.log('css Coverage: ', statsFilter(cssCoverage))
+
+        sendToGraphite({
+          frontendmonitoring: {
+              jsCoverage: {
+                [siteName]: {
+                  [siteType]: statsFilter(jsCoverage)
+                }
+              }
+          }
+        })
+        //console.log('js Coverage: ', statsFilter(jsCoverage))
+
+
+        saveRawData(cssCoverage, `${siteName}_${siteType}_cssCoverage`)
+        saveRawData(jsCoverage, `${siteName}_${siteType}_jsCoverage`)
+
+        await browser.close();
+    })().catch(function (error) {
+      console.error(error)
+    });
+
+/*
+
+  return getCss(url, {
+    headers: {
+      'User-Agent':
+    }
+  }).then(function (response) {
+    const css = getCompleteCss(response.links)
+
+    const results = cssStats(css, {
+      mediaQueries: false,
+      importantDeclarations: true
+    })
+
+    const stats = statsFilter(results)
+
+    const metrics = {
+      frontendmonitoring: {
+          cssstats: {
+            [siteName]: {
+              [siteType]: {
+                stats
+              }
+            }
+          }
+      }
+    }
+    sendToGraphite(metrics)
+
+    // TODO: zentrales console.log, wenn Parameter --verbose gesetzt wurde
+    // console.log(metrics)
+
+    saveRawData(results, `${siteName}_${siteType}_cssstats`)
+
+    return metrics
+  })
+    .catch(function (error) {
+      console.error(error)
+    })
+    */
+}

--- a/src/checks/unused-css-js/check.js
+++ b/src/checks/unused-css-js/check.js
@@ -8,9 +8,12 @@ const CONFIG = require('../../config/config')
 
 async function run(siteName, siteType, url) {
     try {
-        const browser = await puppeteer.launch();
+        const browser = await puppeteer.launch({
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
         const page = await browser.newPage();
-        page.setUserAgent(CONFIG.userAgent)
+        page.setUserAgent(CONFIG.userAgent);
+        await page.setDefaultNavigationTimeout(0);
 
         await Promise.all([
             page.coverage.startJSCoverage(),

--- a/src/checks/unused-css-js/check.js
+++ b/src/checks/unused-css-js/check.js
@@ -6,11 +6,8 @@ const sendToGraphite = require('./../../utils/sendToGraphite')
 const statsFilter = require('./filters/stats')
 const CONFIG = require('../../config/config')
 
-exports = module.exports = {}
-
-exports.run = function run (siteName, siteType, url) {
-
-    return (async () => {
+async function run(siteName, siteType, url) {
+    try {
         const browser = await puppeteer.launch();
         const page = await browser.newPage();
         page.setUserAgent(CONFIG.userAgent)
@@ -32,14 +29,9 @@ exports.run = function run (siteName, siteType, url) {
               cssCoverage: {
                 [siteName]: {
                   [siteType]: statsFilter(cssCoverage)
-                }
-              }
-          }
-        })
-        //console.log('css Coverage: ', statsFilter(cssCoverage))
-
-        sendToGraphite({
-          frontendmonitoring: {
+                },
+              },
+              
               jsCoverage: {
                 [siteName]: {
                   [siteType]: statsFilter(jsCoverage)
@@ -47,14 +39,18 @@ exports.run = function run (siteName, siteType, url) {
               }
           }
         })
+        //console.log('css Coverage: ', statsFilter(cssCoverage))
         //console.log('js Coverage: ', statsFilter(jsCoverage))
 
         saveRawData(cssCoverage, `${siteName}_${siteType}_cssCoverage`)
         saveRawData(jsCoverage, `${siteName}_${siteType}_jsCoverage`)
 
         await browser.close();
-    })().catch(function (error) {
-      console.error(error)
+    } catch((error) => {
+      console.log(error)
     });
-
 }
+
+module.exports = {
+  run,
+};

--- a/src/checks/unused-css-js/check.js
+++ b/src/checks/unused-css-js/check.js
@@ -22,7 +22,6 @@ exports.run = function run (siteName, siteType, url) {
 
         await page.goto(url);
 
-        //Retrive the coverage objects
         const [jsCoverage, cssCoverage] = await Promise.all([
             page.coverage.stopJSCoverage(),
             page.coverage.stopCSSCoverage(),
@@ -50,7 +49,6 @@ exports.run = function run (siteName, siteType, url) {
         })
         //console.log('js Coverage: ', statsFilter(jsCoverage))
 
-
         saveRawData(cssCoverage, `${siteName}_${siteType}_cssCoverage`)
         saveRawData(jsCoverage, `${siteName}_${siteType}_jsCoverage`)
 
@@ -59,44 +57,4 @@ exports.run = function run (siteName, siteType, url) {
       console.error(error)
     });
 
-/*
-
-  return getCss(url, {
-    headers: {
-      'User-Agent':
-    }
-  }).then(function (response) {
-    const css = getCompleteCss(response.links)
-
-    const results = cssStats(css, {
-      mediaQueries: false,
-      importantDeclarations: true
-    })
-
-    const stats = statsFilter(results)
-
-    const metrics = {
-      frontendmonitoring: {
-          cssstats: {
-            [siteName]: {
-              [siteType]: {
-                stats
-              }
-            }
-          }
-      }
-    }
-    sendToGraphite(metrics)
-
-    // TODO: zentrales console.log, wenn Parameter --verbose gesetzt wurde
-    // console.log(metrics)
-
-    saveRawData(results, `${siteName}_${siteType}_cssstats`)
-
-    return metrics
-  })
-    .catch(function (error) {
-      console.error(error)
-    })
-    */
 }

--- a/src/checks/unused-css-js/check.js
+++ b/src/checks/unused-css-js/check.js
@@ -31,7 +31,7 @@ async function run(siteName, siteType, url) {
                   [siteType]: statsFilter(cssCoverage)
                 },
               },
-              
+
               jsCoverage: {
                 [siteName]: {
                   [siteType]: statsFilter(jsCoverage)
@@ -46,9 +46,9 @@ async function run(siteName, siteType, url) {
         saveRawData(jsCoverage, `${siteName}_${siteType}_jsCoverage`)
 
         await browser.close();
-    } catch((error) => {
+    } catch (error) {
       console.log(error)
-    });
+    };
 }
 
 module.exports = {

--- a/src/checks/unused-css-js/filters/stats.js
+++ b/src/checks/unused-css-js/filters/stats.js
@@ -1,0 +1,23 @@
+/**
+ * Get the error, notice and warning statistics for a given puppeteer coverage result
+ *
+ * @param {object} The puppeteer coverage results
+ * @returns {object} Object containing ...
+*/
+module.exports = coverageResults => {
+
+    let totalBytes = 0;
+    let usedBytes = 0;
+    for (const entry of [...coverageResults]) {
+        totalBytes += entry.text.length;
+        for (const range of entry.ranges) {
+            usedBytes += range.end - range.start - 1;
+        }
+    }
+
+    return {
+        totalBytes,
+        usedBytes,
+        coverage: (usedBytes / totalBytes * 100).toFixed(2),
+    }
+}

--- a/src/checks/unused-css-js/index.js
+++ b/src/checks/unused-css-js/index.js
@@ -1,14 +1,20 @@
 const cssstats = require('./check')
 const URLS = require('../../config/urls')
 
+async function wrapper() {
+
 for (const site in URLS) {
   if (site.indexOf('zeit-') !== 0) {
     continue
   }
   for (const type in URLS[site]) {
     const url = URLS[site][type]
-    cssstats.run(site, type, url).then(() => {
+    await cssstats.run(site, type, url).then(() => {
       console.log(`Finished unused-css-js for ${url}`)
-    })
+    });
   }
 }
+
+}
+
+wrapper();

--- a/src/checks/unused-css-js/index.js
+++ b/src/checks/unused-css-js/index.js
@@ -1,0 +1,14 @@
+const cssstats = require('./check')
+const URLS = require('../../config/urls')
+
+for (const site in URLS) {
+  if (site.indexOf('zeit-') !== 0) {
+    continue
+  }
+  for (const type in URLS[site]) {
+    const url = URLS[site][type]
+    cssstats.run(site, type, url).then(() => {
+      console.log(`Finished unused-css-js for ${url}`)
+    })
+  }
+}


### PR DESCRIPTION
Wir wollen die Coverage von JS und CSS – also den Anteil von (un)genutztem Code – in unserem FE Monitoring aufzeichnen. Dafür habe ich die entsprechenden Checks ins Repo eingebaut. Auf den Freitagnachmittag will ich es aber nicht deployen, weil es immer mal wackelt mit Chrome-Fehlern.

Das Dashboard (noch ohne Seiten-Auswahl, nur mal hardcoded für die HP) ist hier: https://grafana.ops.zeit.de/d/4ukzHlwGz/css-and-js-coverage?orgId=1 

<img width="1609" alt="grafik" src="https://user-images.githubusercontent.com/148697/112652950-3d2ec280-8e4e-11eb-850e-2656102dfbf7.png">


Außerdem frage ich mich zum Beispiel noch, warum der Wert leicht? Vermutlich wird externes CSS eingebunden? Aber Consent haben wir ja nicht?